### PR TITLE
[BUGFIX] Links are not generated in the cached tca context

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,17 +1,23 @@
 <?php
 defined('TYPO3_MODE') || die();
 
-$boot = function ($_EXTKEY) {
+call_user_func(function ($_EXTKEY) {
     /** @var array $extConf */
-    $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['px_shopware']);
-    /** @var \TYPO3\CMS\Extbase\SignalSlot\Dispatcher $signalSlotDispatcher */
-    $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
+    $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]);
     /** @var array $version */
     $version = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionStringToArray(TYPO3_version);
 
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
         '<INCLUDE_TYPOSCRIPT: source="DIR:EXT:px_shopware/Configuration/PageTSconfig/" extension="ts">'
     );
+
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'][] =
+        Portrino\PxShopware\Service\Solr\Hooks\Queue::class . '->postProcessFetchRecordsForIndexQueueItem';
+
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typolinkLinkHandler']['shopware_article'] =
+        Portrino\PxShopware\LinkResolver\ArticleLinkResolver::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typolinkLinkHandler']['shopware_category'] =
+        Portrino\PxShopware\LinkResolver\CategoryLinkResolver::class;
 
     switch (TYPO3_MODE) {
         case 'FE':
@@ -272,7 +278,4 @@ $boot = function ($_EXTKEY) {
         unset($GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems'][1435433105]);
     }
 
-};
-
-$boot($_EXTKEY);
-unset($boot);
+}, 'px_shopware');

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,18 +1,6 @@
 <?php
 defined('TYPO3_MODE') || die();
 
-$boot = function ($_EXTKEY) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript',
-        'Shopware Integration');
-
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['solr']['postProcessFetchRecordsForIndexQueueItem'][] =
-        Portrino\PxShopware\Service\Solr\Hooks\Queue::class . '->postProcessFetchRecordsForIndexQueueItem';
-
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typolinkLinkHandler']['shopware_article'] =
-        Portrino\PxShopware\LinkResolver\ArticleLinkResolver::class;
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typolinkLinkHandler']['shopware_category'] =
-        Portrino\PxShopware\LinkResolver\CategoryLinkResolver::class;
-};
-
-$boot($_EXTKEY);
-unset($boot);
+call_user_func(function ($_EXTKEY) {
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Shopware Integration');
+}, 'px_shopware');


### PR DESCRIPTION
In the cached tca context the ext_tables.php files
are not included. Moving the typolinkLinkHandler
registration to the ext_localconf solve this problem.