### PR TITLE
Fix query builder usage in solr queue xclass

### DIFF
--- a/Classes/Xclass/Solr/IndexQueue/Queue.php
+++ b/Classes/Xclass/Solr/IndexQueue/Queue.php
@@ -62,9 +62,11 @@ class Queue extends \ApacheSolrForTypo3\Solr\IndexQueue\Queue {
                 $statement = $queryBuilder
                     ->select('*')
                     ->from($table)
-                    $queryBuilder->expr()->in(
-                        'uid',
-                        $uidList
+                    ->where(
+                        $queryBuilder->expr()->in(
+                            'uid',
+                            $uidList
+                        )
                     )
                     ->execute();
                 while ($row = $statement->fetch()) {


### PR DESCRIPTION
Hi everybody,

there is a small syntax error in the Solr Queue XClass. The usage of QueryBuilder is missing a call to QueryBuild::where() around the 'uid in list' clause.

This PR simply adds the missing function call.

Kind regards
Jona